### PR TITLE
FIX : 로그인 페이지에서만 AuthContext 미실행하도록 변경

### DIFF
--- a/Modi-frontend/src/contexts/AuthContext.tsx
+++ b/Modi-frontend/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   ReactNode,
 } from "react";
+import { useLocation } from "react-router-dom";
 import useLoadUserInfo, { MeResponse } from "../apis/UserAPIS/loadUserInfo";
 
 interface AuthContextType {
@@ -34,6 +35,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [user, setUser] = useState<MeResponse | null>(null);
   const { fetchUserInfo } = useLoadUserInfo();
+  const location = useLocation();
 
   const login = (userData: MeResponse) => {
     setUser(userData);
@@ -61,10 +63,16 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
 
-  // 앱 시작 시 인증 상태 확인
+  // 앱 시작 시 인증 상태 확인 (로그인 페이지 제외)
   useEffect(() => {
-    checkAuth();
-  }, []);
+    // 로그인 페이지가 아닐 때만 인증 확인
+    if (location.pathname !== "/") {
+      checkAuth();
+    } else {
+      // 로그인 페이지에서는 로딩 상태만 false로 설정
+      setIsLoading(false);
+    }
+  }, [location.pathname]);
 
   const value: AuthContextType = {
     isAuthenticated,

--- a/Modi-frontend/src/pages/home/HomePage.tsx
+++ b/Modi-frontend/src/pages/home/HomePage.tsx
@@ -51,13 +51,21 @@ export default function HomePage() {
   // code 파라미터가 있으면 토큰 요청 처리 (중복 방지)
   useEffect(() => {
     const code = getCodeFromURL();
+    console.log("=== OAuth 콜백 처리 시작 ===");
+    console.log("현재 URL:", window.location.href);
+    console.log("code 파라미터:", code);
+
     if (code && !isTokenRequesting.current) {
       isTokenRequesting.current = true;
+      console.log("토큰 요청 시작:", code);
 
       handleTokenRequest(code)
-        .then(() => {})
+        .then(() => {
+          console.log("토큰 요청 성공");
+        })
         .catch((error) => {
-          navigate("/login");
+          console.error("토큰 요청 실패:", error);
+          navigate("/");
         })
         .finally(() => {
           isTokenRequesting.current = false;


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [ ] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [ ] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [ ] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [ ] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] PR 컨벤션에 맞게 작성했습니다. (필수)
- [ ] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [ ] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

- 로그인 페이지에서만 AuthContext 미실행하도록 변경해봤습니다.
- 현재는 로그인 페이지에서부터 AuthContext를 실행하도록 돼있는데, 로그인이 안되는 문제가 있어서 수정했습니다!

## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢
